### PR TITLE
화면 방향 네이티브 설정 기본값으로 변경 : refactor : Android/iOS 네이티브에서 모든 방향 허용, Flut…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:taskAffinity=""
-            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,15 +28,19 @@
     <string>LaunchScreen</string>
     <key>UIMainStoryboardFile</key>
     <string>Main</string>
-    <!-- iPhone 지원 화면 방향: 세로 모드만 허용 -->
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <!-- iPad 지원 화면 방향: 세로 모드만 허용 -->
     <key>UISupportedInterfaceOrientations~ipad</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>CADisableMinimumFrameDurationOnPhone</key>
     <true/>


### PR DESCRIPTION
main.dart에서 세로모드 제어

- Android: screenOrientation="portrait" 제거하여 기본 설정 적용
- iOS: iPhone/iPad에 가로 모드(Landscape) 추가하여 기본 설정 적용
- 화면 방향 제어는 Flutter의 SystemChrome.setPreferredOrientations에서 관리
- main.dart에서 DeviceOrientation.portraitUp만 허용하여 세로 모드 강제
- 네이티브 레벨: 모든 방향 허용, Flutter 레벨: 세로만 강제 (유연한 제어 구조)

https://github.com/TEAM-Tripgether/tripgether-flutter/issues/38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기기 센서에 따라 화면이 자동으로 회전하도록 변경되었습니다.
  * Android에서 세로 방향 고정이 해제되어 가로 모드를 지원합니다.
  * iOS에서 가로 모드를 포함한 다양한 화면 방향을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->