### PR TITLE
fix: Google 로그인 실패 문제 수정 (nickname → name 필드명 변경)

### DIFF
--- a/lib/features/auth/data/models/auth_request.dart
+++ b/lib/features/auth/data/models/auth_request.dart
@@ -28,10 +28,11 @@ class AuthRequest with _$AuthRequest {
     /// 소셜 로그인 API 호출 시 필수
     String? email,
 
-    /// 사용자 닉네임 (선택)
+    /// 사용자 이름 (선택)
     ///
     /// 소셜 로그인 API 호출 시 필수
-    String? nickname,
+    /// 백엔드 DB의 'name' 컬럼과 매핑됨
+    String? name,
 
     /// 프로필 이미지 URL (선택)
     ///
@@ -51,18 +52,18 @@ class AuthRequest with _$AuthRequest {
   ///
   /// [socialPlatform]: "GOOGLE" 또는 "KAKAO"
   /// [email]: 사용자 이메일
-  /// [nickname]: 사용자 닉네임
+  /// [name]: 사용자 이름 (displayName)
   /// [profileUrl]: 프로필 이미지 URL (선택)
   factory AuthRequest.signIn({
     required String socialPlatform,
     required String email,
-    required String nickname,
+    required String name,
     String? profileUrl,
   }) {
     return AuthRequest(
       socialPlatform: socialPlatform,
       email: email,
-      nickname: nickname,
+      name: name,
       profileUrl: profileUrl,
     );
   }

--- a/lib/features/auth/data/models/auth_request.freezed.dart
+++ b/lib/features/auth/data/models/auth_request.freezed.dart
@@ -32,10 +32,11 @@ mixin _$AuthRequest {
   /// 소셜 로그인 API 호출 시 필수
   String? get email => throw _privateConstructorUsedError;
 
-  /// 사용자 닉네임 (선택)
+  /// 사용자 이름 (선택)
   ///
   /// 소셜 로그인 API 호출 시 필수
-  String? get nickname => throw _privateConstructorUsedError;
+  /// 백엔드 DB의 'name' 컬럼과 매핑됨
+  String? get name => throw _privateConstructorUsedError;
 
   /// 프로필 이미지 URL (선택)
   ///
@@ -68,7 +69,7 @@ abstract class $AuthRequestCopyWith<$Res> {
   $Res call({
     String? socialPlatform,
     String? email,
-    String? nickname,
+    String? name,
     String? profileUrl,
     String? refreshToken,
   });
@@ -91,7 +92,7 @@ class _$AuthRequestCopyWithImpl<$Res, $Val extends AuthRequest>
   $Res call({
     Object? socialPlatform = freezed,
     Object? email = freezed,
-    Object? nickname = freezed,
+    Object? name = freezed,
     Object? profileUrl = freezed,
     Object? refreshToken = freezed,
   }) {
@@ -105,9 +106,9 @@ class _$AuthRequestCopyWithImpl<$Res, $Val extends AuthRequest>
                 ? _value.email
                 : email // ignore: cast_nullable_to_non_nullable
                       as String?,
-            nickname: freezed == nickname
-                ? _value.nickname
-                : nickname // ignore: cast_nullable_to_non_nullable
+            name: freezed == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
                       as String?,
             profileUrl: freezed == profileUrl
                 ? _value.profileUrl
@@ -135,7 +136,7 @@ abstract class _$$AuthRequestImplCopyWith<$Res>
   $Res call({
     String? socialPlatform,
     String? email,
-    String? nickname,
+    String? name,
     String? profileUrl,
     String? refreshToken,
   });
@@ -157,7 +158,7 @@ class __$$AuthRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? socialPlatform = freezed,
     Object? email = freezed,
-    Object? nickname = freezed,
+    Object? name = freezed,
     Object? profileUrl = freezed,
     Object? refreshToken = freezed,
   }) {
@@ -171,9 +172,9 @@ class __$$AuthRequestImplCopyWithImpl<$Res>
             ? _value.email
             : email // ignore: cast_nullable_to_non_nullable
                   as String?,
-        nickname: freezed == nickname
-            ? _value.nickname
-            : nickname // ignore: cast_nullable_to_non_nullable
+        name: freezed == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
                   as String?,
         profileUrl: freezed == profileUrl
             ? _value.profileUrl
@@ -194,7 +195,7 @@ class _$AuthRequestImpl implements _AuthRequest {
   const _$AuthRequestImpl({
     this.socialPlatform,
     this.email,
-    this.nickname,
+    this.name,
     this.profileUrl,
     this.refreshToken,
   });
@@ -215,11 +216,12 @@ class _$AuthRequestImpl implements _AuthRequest {
   @override
   final String? email;
 
-  /// 사용자 닉네임 (선택)
+  /// 사용자 이름 (선택)
   ///
   /// 소셜 로그인 API 호출 시 필수
+  /// 백엔드 DB의 'name' 컬럼과 매핑됨
   @override
-  final String? nickname;
+  final String? name;
 
   /// 프로필 이미지 URL (선택)
   ///
@@ -236,7 +238,7 @@ class _$AuthRequestImpl implements _AuthRequest {
 
   @override
   String toString() {
-    return 'AuthRequest(socialPlatform: $socialPlatform, email: $email, nickname: $nickname, profileUrl: $profileUrl, refreshToken: $refreshToken)';
+    return 'AuthRequest(socialPlatform: $socialPlatform, email: $email, name: $name, profileUrl: $profileUrl, refreshToken: $refreshToken)';
   }
 
   @override
@@ -247,8 +249,7 @@ class _$AuthRequestImpl implements _AuthRequest {
             (identical(other.socialPlatform, socialPlatform) ||
                 other.socialPlatform == socialPlatform) &&
             (identical(other.email, email) || other.email == email) &&
-            (identical(other.nickname, nickname) ||
-                other.nickname == nickname) &&
+            (identical(other.name, name) || other.name == name) &&
             (identical(other.profileUrl, profileUrl) ||
                 other.profileUrl == profileUrl) &&
             (identical(other.refreshToken, refreshToken) ||
@@ -261,7 +262,7 @@ class _$AuthRequestImpl implements _AuthRequest {
     runtimeType,
     socialPlatform,
     email,
-    nickname,
+    name,
     profileUrl,
     refreshToken,
   );
@@ -284,7 +285,7 @@ abstract class _AuthRequest implements AuthRequest {
   const factory _AuthRequest({
     final String? socialPlatform,
     final String? email,
-    final String? nickname,
+    final String? name,
     final String? profileUrl,
     final String? refreshToken,
   }) = _$AuthRequestImpl;
@@ -305,11 +306,12 @@ abstract class _AuthRequest implements AuthRequest {
   @override
   String? get email;
 
-  /// 사용자 닉네임 (선택)
+  /// 사용자 이름 (선택)
   ///
   /// 소셜 로그인 API 호출 시 필수
+  /// 백엔드 DB의 'name' 컬럼과 매핑됨
   @override
-  String? get nickname;
+  String? get name;
 
   /// 프로필 이미지 URL (선택)
   ///

--- a/lib/features/auth/data/models/auth_request.g.dart
+++ b/lib/features/auth/data/models/auth_request.g.dart
@@ -10,7 +10,7 @@ _$AuthRequestImpl _$$AuthRequestImplFromJson(Map<String, dynamic> json) =>
     _$AuthRequestImpl(
       socialPlatform: json['socialPlatform'] as String?,
       email: json['email'] as String?,
-      nickname: json['nickname'] as String?,
+      name: json['name'] as String?,
       profileUrl: json['profileUrl'] as String?,
       refreshToken: json['refreshToken'] as String?,
     );
@@ -19,7 +19,7 @@ Map<String, dynamic> _$$AuthRequestImplToJson(_$AuthRequestImpl instance) =>
     <String, dynamic>{
       'socialPlatform': instance.socialPlatform,
       'email': instance.email,
-      'nickname': instance.nickname,
+      'name': instance.name,
       'profileUrl': instance.profileUrl,
       'refreshToken': instance.refreshToken,
     };

--- a/lib/features/auth/providers/login_provider.dart
+++ b/lib/features/auth/providers/login_provider.dart
@@ -125,7 +125,7 @@ class LoginNotifier extends _$LoginNotifier {
         AuthRequest.signIn(
           socialPlatform: 'GOOGLE',
           email: googleUser.email,
-          nickname: googleUser.displayName ?? 'Unknown',
+          name: googleUser.displayName ?? 'Unknown',
           profileUrl: googleUser.photoUrl,
         ),
       );

--- a/lib/features/auth/providers/login_provider.g.dart
+++ b/lib/features/auth/providers/login_provider.g.dart
@@ -6,7 +6,7 @@ part of 'login_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loginNotifierHash() => r'f02741eae35d9cc7748eadc4f9a8d4e0ebfc8f47';
+String _$loginNotifierHash() => r'325d6b0823d521a0547090ef5e68bf7b2878acab';
 
 /// 로그인 상태 관리 Provider
 ///
@@ -32,8 +32,13 @@ String _$rememberMeNotifierHash() =>
 
 /// 자동 로그인 상태 Provider
 ///
-/// 사용자가 "자동로그인" 체크박스를 선택했는지 여부를 관리합니다.
-/// SharedPreferences에 저장되어 앱 재시작 시에도 유지됩니다.
+/// ⚠️ **현재 미사용 기능** - 로그인 화면에서 사용하지 않음
+/// 자동 로그인 기능이 필요하면 구현, 불필요하면 삭제 권장
+///
+/// **구현 계획 (필요 시)**:
+/// 1. SharedPreferences 패키지 추가
+/// 2. 아래 주석 해제하고 로그인 화면에 체크박스 추가
+/// 3. 앱 시작 시 토큰 유효성 검사 후 자동 로그인 처리
 ///
 /// Copied from [RememberMeNotifier].
 @ProviderFor(RememberMeNotifier)

--- a/lib/features/auth/providers/user_provider.g.dart
+++ b/lib/features/auth/providers/user_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$accessTokenHash() => r'8040608299e769f921fffd62ceffbc0b62674a50';
+String _$accessTokenHash() => r'4273519c7d1790d1178aa1d68f56d1c226932c33';
 
 /// Access Token 읽기 Provider
 ///
@@ -35,7 +35,7 @@ final accessTokenProvider = AutoDisposeFutureProvider<String?>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef AccessTokenRef = AutoDisposeFutureProviderRef<String?>;
-String _$refreshTokenHash() => r'181d9979c80444161f641e456867b655d9078c8c';
+String _$refreshTokenHash() => r'f0d9a2d585eb3035384146c7e6e5a81e22b10848';
 
 /// Refresh Token 읽기 Provider
 ///


### PR DESCRIPTION
Production 환경에서 Google 로그인 시 "서버 오류" 발생 문제 해결

문제:
- 백엔드 API는 'name' 필드를 요구하지만 프론트엔드는 'nickname' 필드로 전송
- 서버 DB의 'member.name' 컬럼이 NOT NULL 제약조건을 가지고 있어 null 값 INSERT 실패
- 서버 로그: "null value in column 'name' violates not-null constraint"

해결:
- AuthRequest 모델의 'nickname' 필드를 'name'으로 변경
- LoginProvider에서 Google 사용자 displayName을 'name' 필드로 전송하도록 수정
- Freezed 코드 재생성 (build_runner)

변경 파일:
- lib/features/auth/data/models/auth_request.dart
  * 필드명 변경: nickname → name
  * 주석 업데이트: 백엔드 DB 'name' 컬럼과 매핑됨 명시
- lib/features/auth/providers/login_provider.dart
  * AuthRequest.signIn() 호출 시 nickname → name 파라미터 변경
- Freezed 생성 파일 재생성 (auth_request.freezed.dart, auth_request.g.dart)

테스트:
- flutter analyze 통과 (No issues found)
- Production 환경에서 Google 로그인 테스트 필요

Related: #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * 인증 시스템의 사용자 정보 필드명을 업데이트했습니다. 기존 "nickname" 필드가 "name"으로 변경되었으며, 백엔드 데이터베이스 매핑이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->