### PR TITLE
디자인 변경요청 : fix : 생년월일 입력 모바일 키보드 연속 백스페이스 버그 수정 #52

### DIFF
--- a/lib/features/onboarding/presentation/pages/birthdate_page.dart
+++ b/lib/features/onboarding/presentation/pages/birthdate_page.dart
@@ -194,22 +194,21 @@ class _BirthdatePageState extends ConsumerState<BirthdatePage> {
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
         onChanged: (value) {
           // 모바일 키보드 Backspace 감지
-          // 현재 값이 비어있고, 이전에 값이 있었으며, 첫 번째 필드가 아닌 경우
-          if (value.isEmpty && _previousValues[index].isNotEmpty && index > 0) {
+          // 먼저 이전 값을 저장 (백스페이스 감지를 위해 필요)
+          final previousValue = _previousValues[index];
+
+          // 현재 값으로 업데이트 (항상 먼저 실행!)
+          _previousValues[index] = value;
+
+          // 백스페이스 감지: 현재 비어있고, 이전에 값이 있었고, 첫 번째 필드가 아닌 경우
+          if (value.isEmpty && previousValue.isNotEmpty && index > 0) {
             // 이전 필드 내용 삭제
             _controllers[index - 1].clear();
             _previousValues[index - 1] = '';
             // 이전 필드로 포커스 이동
             _focusNodes[index - 1].requestFocus();
-            _previousValues[index] = '';
             setState(() {});
-            return;
-          }
-
-          // 이전 값 업데이트
-          _previousValues[index] = value;
-
-          if (value.isNotEmpty) {
+          } else if (value.isNotEmpty) {
             // 중간 값 수정 시: 기존 값들을 뒤로 밀어내기
             // 예: 1998 12 02 에서 12의 1을 1로 수정하면
             // → 1998 1(새값) 2(기존 12의 2) 0(기존 02의 0) 2(기존 02의 2)
@@ -242,9 +241,9 @@ class _BirthdatePageState extends ConsumerState<BirthdatePage> {
             if (index < 7) {
               _focusNodes[index + 1].requestFocus();
             }
-          }
 
-          setState(() {}); // 검증 상태 업데이트
+            setState(() {}); // 검증 상태 업데이트
+          }
         },
       ),
     );


### PR DESCRIPTION
…AM-Tripgether/tripgether-flutter/issues/52

모바일 키보드에서 연속 백스페이스 시 2-3번 후 멈추는 버그 해결

문제 상황:
- 휴대폰 키보드로 생년월일 입력 시 백스페이스 2개 지우면 멈춤
- 이후 수동으로 포커싱을 맞춰야 하는 사용성 문제 발생

근본 원인:
- onChanged 콜백에서 return 문이 _previousValues 업데이트를 건너뜀
- 백스페이스 감지 후 상태 변수가 동기화되지 않아 다음 백스페이스 실패
- _previousValues[index]가 이전 값을 계속 유지하여 조건 검사 오작동

수정 내용:
- return 문 제거하고 if-else if 구조로 변경
- _previousValues 업데이트를 onChanged 시작 부분으로 이동
- 지역 변수 previousValue로 이전 값 저장 후 즉시 상태 업데이트
- 모든 코드 경로에서 상태 동기화 보장

기대 효과:
- 모바일 키보드에서 연속 백스페이스 정상 작동
- 물리 키보드와 동일한 사용자 경험 제공
- 수동 포커싱 불필요, 부드러운 입력 흐름 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 모바일 기기에서 백스페이스 처리 개선으로 생일 입력 시 숫자 삭제 정확성 향상
  * 날짜 필드 편집 중 숫자 배열 개선
  * 필드 간 포커스 이동 및 입력 흐름 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->