### PR TITLE
feat(ios): Share Extension 바텀 시트 슬라이드 업 애니메이션 추가

### DIFF
--- a/ios/Share Extension/ShareViewController.swift
+++ b/ios/Share Extension/ShareViewController.swift
@@ -471,13 +471,31 @@ class ShareViewController: UIViewController {
     private func showSuccessAndDismiss() {
         print("[ShareExtension] 데이터 저장 완료 - UI는 사용자가 닫을 때까지 유지")
 
+        // 🎬 바텀 시트 애니메이션: 아래에서 위로 올라오기
+        DispatchQueue.main.async {
+            UIView.animate(
+                withDuration: 0.3,
+                delay: 0,
+                usingSpringWithDamping: 0.8,
+                initialSpringVelocity: 0.5,
+                options: .curveEaseOut,
+                animations: {
+                    // 화면 밖(아래쪽)에서 원래 위치로 이동
+                    self.customContainerView?.transform = .identity
+                },
+                completion: { _ in
+                    print("[ShareExtension] ✅ 바텀 시트 애니메이션 완료")
+                }
+            )
+        }
+
         // ⚠️ 알림 발송 제거 (커스텀 UI로 대체)
         // sendLocalNotification()
 
         // ⚠️ 자동 앱 실행 제거 (사용자가 버튼을 누를 때만 실행)
         // openMainApp()
 
-        // ⚠️ 자동 닫기 제거 - UI는 ��용자가 수동으로 닫을 때까지 유지
+        // ⚠️ ���동 닫기 제거 - UI는 ��용자가 수동으로 닫을 때까지 유지
         // 사용자는 다음 방법으로 닫을 수 있음:
         // 1. "앱에서 보기" 버튼 클릭 → openAppAndDismiss() 실행
         // 2. 아래로 스와이프 → handlePanGesture() 실행
@@ -492,7 +510,7 @@ class ShareViewController: UIViewController {
     private func sendLocalNotification() {
         let content = UNMutableNotificationContent()
         content.title = "✓ Tripgether에 저장됨"
-        content.body = "탭하여 공유된 콘텐츠를 확인하세요"
+        content.body = "���하여 공유된 콘텐츠를 확인하세요"
         content.sound = .default
 
         // 즉시 발송 (0.1초 후)
@@ -720,6 +738,9 @@ class ShareViewController: UIViewController {
         containerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(containerView)
         self.customContainerView = containerView
+
+        // 🎬 초기 위치: 화면 아래에서 시작 (화면 밖)
+        containerView.transform = CGAffineTransform(translationX: 0, y: 180)
 
         // 컨테이너 뷰 팬 제스처 추가 (아래로 스와이프 시 닫기)
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))


### PR DESCRIPTION
외부 앱에서 공유 시 Share Extension UI가 화면 아래에서 부드럽게 올라오는
애니메이션 효과를 구현했습니다.

주요 변경사항:
- showSuccessAndDismiss() 함수에 UIView.animate 추가
- 스프링 애니메이션으로 자연스러운 바텀 시트 슬라이드 업 구현
- 초기 위치(y: 180 오프스크린) → 최종 위치(transform: .identity) 애니메이션
- 0.3초 duration, 0.8 damping으로 약간의 바운스 효과 추가

기술 상세:
- DispatchQueue.main.async로 메인 스레드에서 UI 업데이트 보장
- usingSpringWithDamping: 0.8로 자연스러운 감속 효과
- initialSpringVelocity: 0.5로 적절한 시작 속도 설정
- curveEaseOut으로 부드러운 감속 커브 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 성공 메시지 표시 시 스프링 효과가 있는 부드러운 애니메이션 적용
  * UI 컨테이너 진입 애니메이션 개선으로 더욱 자연스러운 사용자 경험 제공

* **버그 수정**
  * 알림 및 콘텐츠 문자열의 인코딩 문제 해결

<!-- end of auto-generated comment: release notes by coderabbit.ai -->