### PR TITLE
fix(ios): Instagram 공유 시트 표시 개선 - @objc 명시적 클래스 이름 지정

### DIFF
--- a/ios/Share Extension/Info.plist
+++ b/ios/Share Extension/Info.plist
@@ -45,8 +45,10 @@
 				<integer>1</integer>
             </dict>
         </dict>
+		<!-- NSExtensionPrincipalClass: 모듈 이름 제거하여 @objc 어노테이션과 일치시킴 -->
+		<!-- Swift-Objective-C 브릿징을 명확하게 하여 iOS 시스템의 Extension 인식 개선 -->
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<string>ShareViewController</string>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.share-services</string>
 	</dict>

--- a/ios/Share Extension/ShareViewController.swift
+++ b/ios/Share Extension/ShareViewController.swift
@@ -15,6 +15,10 @@ import Photos
 import AVFoundation
 import UserNotifications
 
+/// Share Extension의 메인 뷰 컨트롤러
+/// @objc 어노테이션: Swift-Objective-C 브릿징을 명확하게 하여
+/// iOS 시스템이 NSExtensionPrincipalClass로부터 이 클래스를 올바르게 인식하도록 함
+@objc(ShareViewController)
 class ShareViewController: UIViewController {
     // IMPORTANT: 메인 앱의 Bundle Identifier와 동일하게 설정 (App Group ID 접두사로도 사용)
     let hostAppBundleIdentifier = "com.tripgether.alom"


### PR DESCRIPTION
## 변경 사항

### ShareViewController.swift
- `@objc(ShareViewController)` 어노테이션 추가
- Swift-Objective-C 브릿징을 명확하게 하여 iOS 시스템의 Extension 인식 개선
- 클래스 상단에 설명 주석 추가

### Info.plist
- NSExtensionPrincipalClass 값 변경:
  - 변경 전: `$(PRODUCT_MODULE_NAME).ShareViewController`
  - 변경 후: `ShareViewController`
- 모듈 이름 언더스코어 문제 회피
- 설명 주석 추가

## 문제 해결

Instagram 공유 시트에서 Tripgether 앱이 표시되지 않는 문제 해결:
- 모듈 이름 `Share_Extension`의 언더스코어가 Objective-C 런타임 인식 문제 유발
- @objc 어노테이션으로 명시적 클래스 이름 지정하여 해결

## 기대 효과

- Instagram 공유 시트에서 Tripgether 앱 정상 표시
- iOS 시스템의 Share Extension 인식 개선
- 현재 커스텀 바텀 시트 UI 유지
- 최소한의 코드 변경 (2개 파일, 주석 제외 실질 변경 2줄)

## 테스트 필요

1. TestFlight 빌드 업로드
2. Instagram에서 공유 시트 열기
3. Tripgether 앱이 공유 대상 목록에 표시되는지 확인

Related to #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 공유 확장 기능이 이제 iOS 시스템에서 올바르게 인식되고 초기화되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->