### PR TITLE
20251123_#86_기능추가_인증_푸시알림_로그인_API_FCM_토큰_필드_추가_및_멀티_디바이스_푸시_알림_지원_기능_…

### DIFF
--- a/.github/workflows/PROJECT-IOS-TESTFLIGHT-CICD.yml
+++ b/.github/workflows/PROJECT-IOS-TESTFLIGHT-CICD.yml
@@ -321,7 +321,7 @@ jobs:
               <dict>
                   <key>com.tripgether.alom</key>
                   <string>${{ steps.install_profile.outputs.profile_name }}</string>
-                  <key>com.tripgether.alom.Share-Extension</key>
+                  <key>com.tripgether.alom.share</key>
                   <string>${{ steps.install_profile.outputs.share_profile_name }}</string>
               </dict>
               <key>signingStyle</key>
@@ -410,14 +410,14 @@ jobs:
           # Share Extension 타겟 설정 (있는 경우)
           share_profile = '${{ steps.install_profile.outputs.share_profile_name }}'
           if !share_profile.empty?
-            share_target = project.targets.find { |t| t.name == 'Share Extension' }
+            share_target = project.targets.find { |t| t.name == 'share' }
             if share_target
               share_target.build_configurations.each do |config|
                 if config.name == 'Release'
                   config.build_settings['CODE_SIGN_STYLE'] = 'Manual'
                   config.build_settings['CODE_SIGN_IDENTITY'] = 'Apple Distribution'
                   config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = share_profile
-                  puts "✅ Share Extension target configured with profile: #{share_profile}"
+                  puts "✅ share target configured with profile: #{share_profile}"
                 end
               end
             end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -705,7 +705,7 @@
 				INFOPLIST_FILE = share/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = share;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -749,7 +749,7 @@
 				INFOPLIST_FILE = share/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = share;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -790,7 +790,7 @@
 				INFOPLIST_FILE = share/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = share;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
…추가 : fix : Share Extension 설정 오류 수정 #86

## 수정 내용

### iOS Deployment Target 수정
- share 타겟: 26.0 → 17.6 (Debug, Release, Profile)
- 커밋 910c209에서 iOS 26.0으로 잘못 설정된 부분 수정
- 메인 앱(17.6)과 통일하여 Xcode 16.3 지원 범위 준수

### CI/CD 워크플로우 업데이트
- Bundle ID: com.tripgether.alom.Share-Extension → com.tripgether.alom.share
- Ruby 스크립트 타겟명: 'Share Extension' → 'share'
- ExportOptions.plist Bundle ID 동기화

## 문제 분석

### 원인
- 커밋 910c209: Share Extension 리팩토링 중 Deployment Target을 26.0으로 오타
- iOS 26은 존재하지 않는 버전 (Xcode 16.3 최대 지원: 18.4)

### 빌드 실패 로그
```
error: No profiles for 'com.tripgether.alom.share' were found
warning: IPHONEOS_DEPLOYMENT_TARGET is set to 26.0,
         but supported range is 12.0 to 18.4.99
```

## 다음 단계

Apple Developer Console에서 Provisioning Profile 생성 후 GitHub Secrets 추가 필요:
- Bundle ID: com.tripgether.alom.share
- Secret Name: IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * iOS 배포 대상 버전을 17.6으로 조정하여 더 많은 iOS 기기 지원 범위 확대
  
* **빌드/배포**
  * Share Extension 구성 요소 설정 업데이트로 빌드 프로세스 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->